### PR TITLE
use setuptools, declare bibtexparser as dependency, trove classifiers, restructure version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_version.py
 .backups
 *.bak
 *.py[co]

--- a/libcitebib/__init__.py
+++ b/libcitebib/__init__.py
@@ -22,4 +22,8 @@ from .main import *
 from .utils import *
 from .writer import *
 
-__version__ = '0.4.3'
+
+try:
+    from ._version import version as __version__
+except:
+    __version__ = None

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,22 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-from libcitebib import __version__ as version
+
+VERSION_FILE = 'libcitebib/_version.py'
+MAJOR = 0
+MINOR = 4
+MICRO = 3
+VERSION = '{major}.{minor}.{micro}'.format(
+    major=MAJOR, minor=MINOR, micro=MICRO)
+VERSION_TEXT = (
+    '# This file was generated from setup.py\n'
+    "version = '{version}'\n")
 
 def run_setup():
+    version = VERSION
+    s = VERSION_TEXT.format(version=version)
+    with open(VERSION_FILE, 'w') as f:
+        f.write(s)
     setup(
         name='CiteBib',
         version=version,

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,20 @@ from setuptools import setup
 
 from libcitebib import __version__ as version
 
-setup(
-    name         = 'CiteBib',
-    version      = version,
-    url          = "https://github.com/sciunto-org/python-bibtexparser",
-    author       = "Francois Boulogne",
-    license      = "GPLv3+",
-    author_email = "fboulogne@sciunt.org",
-    description  = "Generate a nice Bibtex or Latex bibliography according to the document content",
-    packages     = ['libcitebib'],
-    scripts      = ['citebib', 'citekey'],
-)
+def run_setup():
+    setup(
+        name='CiteBib',
+        version=version,
+        url="https://github.com/sciunto-org/python-bibtexparser",
+        author="Francois Boulogne",
+        license="GPLv3+",
+        author_email="fboulogne@sciunt.org",
+        description=(
+            "Generate a nice Bibtex or Latex bibliography "
+            "according to the document content"),
+        packages=['libcitebib'],
+        scripts=['citebib', 'citekey'],
+
+
+if __name__ == '__main__':
+    run_setup()

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ VERSION = '{major}.{minor}.{micro}'.format(
 VERSION_TEXT = (
     '# This file was generated from setup.py\n'
     "version = '{version}'\n")
+install_requires = [
+    'bibtexparser']
 
 def run_setup():
     version = VERSION
@@ -29,6 +31,7 @@ def run_setup():
             "according to the document content"),
         packages=['libcitebib'],
         scripts=['citebib', 'citekey'],
+        install_requires=install_requires,
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,16 @@ VERSION_TEXT = (
     "version = '{version}'\n")
 install_requires = [
     'bibtexparser']
+classifiers = [
+    'Development Status :: 2 - Pre-Alpha',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3',
+    'Topic :: Scientific/Engineering',
+    'Topic :: Software Development']
+
 
 def run_setup():
     version = VERSION
@@ -32,6 +42,7 @@ def run_setup():
         packages=['libcitebib'],
         scripts=['citebib', 'citekey'],
         install_requires=install_requires,
+        classifiers = classifiers)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def run_setup():
         url="https://github.com/sciunto-org/python-bibtexparser",
         author="Francois Boulogne",
         license="GPLv3+",
-        author_email="fboulogne@sciunt.org",
+        author_email="devel@sciunto.org",
         description=(
             "Generate a nice Bibtex or Latex bibliography "
             "according to the document content"),

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
+from setuptools import setup
 
-try:
-    from setuptools import setup
-except ImportError as ex:
-    print('[python-bibtexparser] setuptools not found. Falling back to distutils.core')
-    from distutils.core import setup
 from libcitebib import __version__ as version
 
 setup(


### PR DESCRIPTION
Installation:

- fails in Python 2 due to invalid syntax (classifiers prevent attempting to install in the first place)
- fails in Python 3 due to the (undeclared) dependency `bibtexparser` not being installed yet (need to define `install_requires`).
- fails due to attempting to obtain the version from inside the package, which attempts to import the package, and fails (this will happen always before `bibtexparser` is fetched yet, even when declared as a dependency).

These commits address the above issues.
The proposed `setup.py` structure originates from [`dd/setup.py`](https://github.com/johnyf/dd/blob/c535dee7a2e0d4c7312c383855c6239e87afcd37/setup.py)